### PR TITLE
修正自部署反代的跨域错误与文件缩进调整

### DIFF
--- a/lb.www.gdgdocs.org.conf
+++ b/lb.www.gdgdocs.org.conf
@@ -1,0 +1,69 @@
+
+server{
+
+    listen 80;
+    server_name 0.www.gdgdocs.org 1.www.gdgdocs.org 2.www.gdgdocs.org;
+    return 301 https://www.gdgdocs.org$request_uri;
+}
+
+server{
+
+    listen 443 ssl;
+    ssl on;
+    server_name 0.www.gdgdocs.org 1.www.gdgdocs.org 2.www.gdgdocs.org;
+    ssl_certificate /home/certs/www.gdgdocs.org.cer;
+    ssl_certificate_key /home/certs/www.gdgdocs.org.pem;
+    add_header Access-Control-Allow-Credentials true;
+    add_header Access-Control-Allow-Headers "X-Same-Domain";
+
+    # SSL Config By CloudFlare https://github.com/cloudflare/sslconfig
+    ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers                 EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:EECDH+RC4:RSA+RC4:!MD5;
+    ssl_prefer_server_ciphers   on;
+
+    location / {
+    if ( $request_uri = "/" ) {
+        rewrite ^(.*)$ https://www.gdgdocs.org/document/d/1rnaqhGV61oLkUxYY0_t7u_uwqDLeNHhvQEBxZext1Gw/pub?embedded=true permanent;
+    }
+    subs_filter_types text/css text/js;
+    proxy_set_header Accept-Encoding '';
+    proxy_pass https://0.docs.google.com;
+    subs_filter docs.google.com www.gdgdocs.org
+    subs_filter lh1.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh2.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh3.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh4.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh5.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh6.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh7.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh8.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh9.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter lh10.googleusercontent.com dn-ggpt.qbox.me;
+    subs_filter ssl.gstatic.com dn-gstatic.qbox.me;
+    subs_filter www.gstatic.com dn-gstatic.qbox.me;
+
+    proxy_redirect off;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Cookie "";
+    proxy_hide_header Set-Cookie;
+    more_clear_headers "P3P";
+    proxy_hide_header Location;
+
+    }
+
+    location /r/ {
+                proxy_pass         http://goo.gl/;
+                proxy_set_header   Host goo.gl;
+                proxy_set_header   X-Real-IP  $remote_addr;
+                proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location ^~ /qr/ {
+                proxy_pass http://chart.apis.google.com/chart?cht=qr&chs=500x500&chld=H|0&chl=https%3A//gdgdoc
+s.org/r/;
+                proxy_set_header   Host chart.apis.google.com;
+                proxy_set_header   X-Real-IP  $remote_addr;
+                proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+}

--- a/lb.www.gdgdocs.org.conf
+++ b/lb.www.gdgdocs.org.conf
@@ -1,13 +1,10 @@
-
-server{
-
+server {
     listen 80;
     server_name 0.www.gdgdocs.org 1.www.gdgdocs.org 2.www.gdgdocs.org;
     return 301 https://www.gdgdocs.org$request_uri;
 }
 
-server{
-
+server {
     listen 443 ssl;
     ssl on;
     server_name 0.www.gdgdocs.org 1.www.gdgdocs.org 2.www.gdgdocs.org;
@@ -22,48 +19,46 @@ server{
     ssl_prefer_server_ciphers   on;
 
     location / {
-    if ( $request_uri = "/" ) {
-        rewrite ^(.*)$ https://www.gdgdocs.org/document/d/1rnaqhGV61oLkUxYY0_t7u_uwqDLeNHhvQEBxZext1Gw/pub?embedded=true permanent;
-    }
-    subs_filter_types text/css text/js;
-    proxy_set_header Accept-Encoding '';
-    proxy_pass https://0.docs.google.com;
-    subs_filter docs.google.com www.gdgdocs.org
-    subs_filter lh1.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh2.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh3.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh4.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh5.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh6.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh7.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh8.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh9.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter lh10.googleusercontent.com dn-ggpt.qbox.me;
-    subs_filter ssl.gstatic.com dn-gstatic.qbox.me;
-    subs_filter www.gstatic.com dn-gstatic.qbox.me;
+        if ( $request_uri = "/" ) {
+            rewrite ^(.*)$ https://www.gdgdocs.org/document/d/1rnaqhGV61oLkUxYY0_t7u_uwqDLeNHhvQEBxZext1Gw/pub?embedded=true permanent;
+        }
+        subs_filter_types text/css text/js;
+        proxy_set_header Accept-Encoding '';
+        proxy_pass https://0.docs.google.com;
+        subs_filter docs.google.com www.gdgdocs.org
+        subs_filter lh1.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh2.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh3.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh4.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh5.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh6.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh7.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh8.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh9.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter lh10.googleusercontent.com dn-ggpt.qbox.me;
+        subs_filter ssl.gstatic.com dn-gstatic.qbox.me;
+        subs_filter www.gstatic.com dn-gstatic.qbox.me;
 
-    proxy_redirect off;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Cookie "";
-    proxy_hide_header Set-Cookie;
-    more_clear_headers "P3P";
-    proxy_hide_header Location;
-
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Cookie "";
+        proxy_hide_header Set-Cookie;
+        more_clear_headers "P3P";
+        proxy_hide_header Location;
     }
 
     location /r/ {
-                proxy_pass         http://goo.gl/;
-                proxy_set_header   Host goo.gl;
-                proxy_set_header   X-Real-IP  $remote_addr;
-                proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
+        proxy_pass         http://goo.gl/;
+        proxy_set_header   Host goo.gl;
+        proxy_set_header   X-Real-IP  $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 
-        location ^~ /qr/ {
-                proxy_pass http://chart.apis.google.com/chart?cht=qr&chs=500x500&chld=H|0&chl=https%3A//gdgdoc
-s.org/r/;
-                proxy_set_header   Host chart.apis.google.com;
-                proxy_set_header   X-Real-IP  $remote_addr;
-                proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
+    location ^~ /qr/ {
+        proxy_pass http://chart.apis.google.com/chart?cht=qr&chs=500x500&chld=H|0&chl=https%3A//gdgdocs.org/r/;
+        proxy_set_header   Host chart.apis.google.com;
+        proxy_set_header   X-Real-IP  $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 }

--- a/src/centos.sh
+++ b/src/centos.sh
@@ -21,7 +21,7 @@ read -p "输入要部署 GDocs 反向代理的域名： " domain
 if [ ! -f "/usr/local/nginx/conf/vhost/$domain.conf" ]; then
 echo "==========================="
 echo "domain=$domain"
-echo "===========================" 
+echo "==========================="
 else
 echo "==========================="
 echo "$domain 已经存在咯!"
@@ -112,6 +112,60 @@ server
             proxy_set_header Accept-Encoding '';
             subs_filter_types text/css text/js;
             proxy_pass https://$gdoc_source/;
+            subs_filter docs.google.com  $domain
+            subs_filter lh1.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh2.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh3.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh4.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh5.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh6.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh7.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh8.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh9.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter lh10.googleusercontent.com dn-ggpt.qbox.me;
+            subs_filter ssl.gstatic.com dn-gstatic.qbox.me;
+            subs_filter www.gstatic.com dn-gstatic.qbox.me;
+
+            proxy_redirect          off;
+            proxy_set_header        X-Real-IP       \$remote_addr;
+            proxy_set_header        X-Forwarded-For \$proxy_add_x_forwarded_for;
+            proxy_set_header        Cookie "";
+            proxy_hide_header       Set-Cookie;
+            more_clear_headers      "P3P";
+
+            proxy_hide_header Location;
+          }
+
+          location /r/ {
+                proxy_pass         https://$short_source/;
+                proxy_set_header   Host goo.gl;
+                proxy_set_header   X-Real-IP  \$remote_addr;
+                proxy_set_header   X-Forwarded-For \$proxy_add_x_forwarded_for;
+           }
+
+          location ^~ /qr/ {
+                proxy_pass         https://$qr_source/chart?cht=qr&chs=500x500&chld=H|0&chl=http%3A//$domain/r/;
+                proxy_set_header   Host chart.apis.google.com;
+                proxy_set_header   X-Real-IP  \$remote_addr;
+                proxy_set_header   X-Forwarded-For \$proxy_add_x_forwarded_for;
+           }
+     }
+eof
+
+cat > /usr/local/nginx/conf/vhost/lb.$domain.conf << eof
+# 注意，这里提供的 dn-ggpt.qbox.me 等，是七牛为公益开发者社区的提供的赞助，请商业公司自行搭建，谢谢。
+server
+     {
+          listen       80;
+          server_name 0.$domain 1.$domain 2.$domain;
+          # conf ssl if you need
+          # SSL 配置请参见 gdgny.org/project/gdgdocs
+          add_header Access-Control-Allow-Credentials true;
+          add_header Access-Control-Allow-Headers "X-Same-Domain";
+          location / {
+            proxy_set_header Accept-Encoding '';
+            subs_filter_types text/css text/js;
+            proxy_pass https://0.$gdoc_source/;
             subs_filter docs.google.com  $domain
             subs_filter lh1.googleusercontent.com dn-ggpt.qbox.me;
             subs_filter lh2.googleusercontent.com dn-ggpt.qbox.me;

--- a/www.gdgdocs.org.conf
+++ b/www.gdgdocs.org.conf
@@ -1,66 +1,62 @@
-server{
-
+server {
 	listen 80;
 	server_name gdgdocs.org www.gdgdocs.org;
 	return 301 https://www.gdgdocs.org$request_uri;
 }
 
-server{
-
+server {
 	listen 443 ssl;
 	ssl on;
 	server_name gdgdocs.org www.gdgdocs.org;
 	ssl_certificate /home/certs/www.gdgdocs.org.cer;
 	ssl_certificate_key /home/certs/www.gdgdocs.org.pem;
-	
+
 	# SSL Config By CloudFlare https://github.com/cloudflare/sslconfig
 	ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
 	ssl_ciphers                 EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:EECDH+RC4:RSA+RC4:!MD5;
 	ssl_prefer_server_ciphers   on;
 
 	location / {
-	if ( $request_uri = "/" ) {
-		rewrite ^(.*)$ https://www.gdgdocs.org/document/d/1rnaqhGV61oLkUxYY0_t7u_uwqDLeNHhvQEBxZext1Gw/pub?embedded=true permanent;
-	}
-	subs_filter_types text/css text/js;
-	proxy_set_header Accept-Encoding '';
-	proxy_pass https://docs.google.com;
-	subs_filter docs.google.com www.gdgdocs.org
-	subs_filter lh1.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh2.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh3.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh4.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh5.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh6.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh7.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh8.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh9.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter lh10.googleusercontent.com dn-ggpt.qbox.me;
-	subs_filter ssl.gstatic.com dn-gstatic.qbox.me;
-	subs_filter www.gstatic.com dn-gstatic.qbox.me;
+    	if ( $request_uri = "/" ) {
+    		rewrite ^(.*)$ https://www.gdgdocs.org/document/d/1rnaqhGV61oLkUxYY0_t7u_uwqDLeNHhvQEBxZext1Gw/pub?embedded=true permanent;
+    	}
+    	subs_filter_types text/css text/js;
+    	proxy_set_header Accept-Encoding '';
+    	proxy_pass https://docs.google.com;
+    	subs_filter docs.google.com www.gdgdocs.org
+    	subs_filter lh1.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh2.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh3.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh4.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh5.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh6.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh7.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh8.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh9.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter lh10.googleusercontent.com dn-ggpt.qbox.me;
+    	subs_filter ssl.gstatic.com dn-gstatic.qbox.me;
+    	subs_filter www.gstatic.com dn-gstatic.qbox.me;
 
-	proxy_redirect off;
-	proxy_set_header X-Real-IP $remote_addr;
-	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	proxy_set_header Cookie "";
-	proxy_hide_header Set-Cookie;
-	more_clear_headers "P3P";
-	proxy_hide_header Location;
-
+    	proxy_redirect off;
+    	proxy_set_header X-Real-IP $remote_addr;
+    	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    	proxy_set_header Cookie "";
+    	proxy_hide_header Set-Cookie;
+    	more_clear_headers "P3P";
+    	proxy_hide_header Location;
 	}
-	
+
 	location /r/ {
-                proxy_pass         http://goo.gl/;
-                proxy_set_header   Host goo.gl;
-                proxy_set_header   X-Real-IP  $remote_addr;
-                proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-        
-        location ^~ /qr/ {
-                proxy_pass http://chart.apis.google.com/chart?cht=qr&chs=500x500&chld=H|0&chl=https%3A//gdgdoc
-s.org/r/;
-                proxy_set_header   Host chart.apis.google.com;
-                proxy_set_header   X-Real-IP  $remote_addr;
-                proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
+        proxy_pass         http://goo.gl/;
+        proxy_set_header   Host goo.gl;
+        proxy_set_header   X-Real-IP  $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ^~ /qr/ {
+        proxy_pass http://chart.apis.google.com/chart?cht=qr&chs=500x500&chld=H|0&chl=https%3A//gdgdocs.org/r/;
+        proxy_set_header   Host chart.apis.google.com;
+        proxy_set_header   X-Real-IP  $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 }


### PR DESCRIPTION
最近更新后的 Google Docs 新增了通信过程的负载均衡，使用 *.proxy_domain 做负载均衡代理
本commit添加了三个负载均衡的代理，自动转发。

同时存在一个typo: https://github.com/GDGNanyang/gdgdocs/blob/master/www.gdgdocs.org.conf#L60-L61
这里的配置中间断开了，导致配置自检不通过。